### PR TITLE
More unit tests

### DIFF
--- a/src/test/java/ch/hearc/todont/models/CommentTest.java
+++ b/src/test/java/ch/hearc/todont/models/CommentTest.java
@@ -1,7 +1,58 @@
 package ch.hearc.todont.models;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.hearc.todont.models.ToDont.Visibility;
+import org.junit.jupiter.api.Test;
+
 public class CommentTest {
 
-    // No methods in Comment class
+    @Test
+    public void givenACommentAndItsOwner_whenCallCanDelete_thenReturnTrue() {
+        User owner = new User();
+        User commenter = new User();
+
+        ToDont toDont = new ToDont(owner, "Test", Visibility.PUBLIC);
+        Pledge pledge = new Pledge(commenter, toDont);
+
+        Comment comment = new Comment(pledge, "Hello");
+
+        assertTrue(comment.canDelete(commenter));
+    }
     
+    @Test
+    public void givenACommenterAndAModerator_whenCallCanDelete_thenReturnTrue() {
+        User owner = new User();
+        User moderator = new User();
+        User commenter = new User();
+
+        ToDont toDont = new ToDont(owner, "Test", Visibility.PUBLIC);
+        
+        Pledge commenterPledge = new Pledge(commenter, toDont);
+        
+        new Pledge(moderator, toDont);
+        toDont.addModerator(owner, moderator);
+
+        Comment comment = new Comment(commenterPledge, "Hello");
+
+        assertTrue(comment.canDelete(moderator));
+    }
+
+    @Test
+    public void givenACommenterAndANonModerator_whenCallCanDelete_thenReturnFalse() {
+        User owner = new User();
+        User anyone = new User();
+        User commenter = new User();
+
+        ToDont toDont = new ToDont(owner, "Test", Visibility.PUBLIC);
+        
+        Pledge commenterPledge = new Pledge(commenter, toDont);
+        
+        new Pledge(anyone, toDont);
+
+        Comment comment = new Comment(commenterPledge, "Hello");
+
+        assertFalse(comment.canDelete(anyone));
+    }
 }

--- a/src/test/java/ch/hearc/todont/models/PledgeTest.java
+++ b/src/test/java/ch/hearc/todont/models/PledgeTest.java
@@ -1,5 +1,6 @@
 package ch.hearc.todont.models;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ch.hearc.todont.models.ToDont.Visibility;
@@ -17,5 +18,29 @@ public class PledgeTest {
         pledge.fail();
 
         assertTrue(pledge.isFailed());
+    }
+
+    @Test
+    public void givenAModeratorPledge_whenCallisModerator_thenReturnTrue() {
+        User owner = new User();
+        User mod = new User();
+
+        ToDont toDont = new ToDont(owner, "Test", Visibility.PUBLIC);
+        Pledge pledge = new Pledge(mod, toDont);
+
+        toDont.addModerator(owner, mod);
+
+        assertTrue(pledge.isModerator());
+    }
+
+    @Test
+    public void givenANonModeratorPledge_whenCallisModerator_thenReturnFalse() {
+        User owner = new User();
+        User mod = new User();
+
+        ToDont toDont = new ToDont(owner, "Test", Visibility.PUBLIC);
+        Pledge pledge = new Pledge(mod, toDont);
+
+        assertFalse(pledge.isModerator());
     }
 }

--- a/src/test/java/ch/hearc/todont/models/ToDontTest.java
+++ b/src/test/java/ch/hearc/todont/models/ToDontTest.java
@@ -3,9 +3,8 @@ package ch.hearc.todont.models;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.Test;
-
 import ch.hearc.todont.models.ToDont.Visibility;
+import org.junit.jupiter.api.Test;
 
 public class ToDontTest {
 
@@ -62,5 +61,91 @@ public class ToDontTest {
         toDont.close(user);
 
         assertTrue(toDont.isClosed());
+    }
+
+    @Test
+    public void givenAPledgedUser_whenCallIsPledged_thenReturnTrue() {
+        User owner = new User();
+        User user = new User();
+        
+        ToDont toDont = new ToDont(owner, "Test", Visibility.PUBLIC);
+        toDont.getPledges().add(new Pledge(user, toDont));
+
+        assertTrue(toDont.isPledged(user));
+    }
+
+    @Test
+    public void givenANonPledgedUser_whenCallIsPledged_thenReturnTrue() {
+        User owner = new User();
+        User user = new User();
+        
+        ToDont toDont = new ToDont(owner, "Test", Visibility.PUBLIC);
+
+        assertFalse(toDont.isPledged(user));
+    }
+
+    @Test
+    public void givenAUserThatHasFailed_whenCallHasFailed_thenReturnTrue() {
+        User owner = new User();
+        User user = new User();
+        
+        ToDont toDont = new ToDont(owner, "Test", Visibility.PUBLIC);
+        Pledge pledge = new Pledge(user, toDont);
+        toDont.getPledges().add(pledge);
+
+        pledge.fail();
+
+        assertTrue(toDont.hasFailed(user));
+    }
+
+    @Test
+    public void givenAUserThatHasNotFailed_whenCallHasFailed_thenReturnFalse() {
+        User owner = new User();
+        User user = new User();
+        
+        ToDont toDont = new ToDont(owner, "Test", Visibility.PUBLIC);
+        Pledge pledge = new Pledge(user, toDont);
+        toDont.getPledges().add(pledge);
+
+        assertFalse(toDont.hasFailed(user));
+    }
+
+    @Test
+    public void givenAToDontWith0Failures_whenCallGetNumberOfFailures_thenReturn0() {
+        User owner = new User();
+        ToDont toDont = new ToDont(owner, "Test", Visibility.PUBLIC);
+
+        assertTrue(toDont.getNumberOfFailures() == 0);
+    }
+
+    private void generateFailures(ToDont toDont, int failures) {
+        for (int i = 0; i < failures; i++) {
+            User user = new User();
+            
+            Pledge pledge = new Pledge(user, toDont);
+            toDont.getPledges().add(pledge);
+
+            pledge.fail();
+        }
+    }
+
+    @Test
+    public void givenAToDontWith1Failure_whenCallGetNumberOfFailures_thenReturn1() {
+        User owner = new User();
+        ToDont toDont = new ToDont(owner, "Test", Visibility.PUBLIC);
+
+        generateFailures(toDont, 1);
+
+        assertTrue(toDont.getNumberOfFailures() == 1);
+    }
+
+    @Test
+    public void givenAToDontWith2Failures_whenCallGetNumberOfFailures_thenReturn2() {
+        User owner = new User();
+        ToDont toDont = new ToDont(owner, "Test", Visibility.PUBLIC);
+
+        generateFailures(toDont, 2);
+
+        assertTrue(toDont.getNumberOfFailures() == 2);
     }
 }


### PR DESCRIPTION
Close #29 

Note : the public method `ToDont::getCommentsAntiChronological` isn't tested because of the numerous cases. It appears testing this functionality is better done in the views.